### PR TITLE
Release 0.1.1 - Add missing `[` in task definition template

### DIFF
--- a/task-definition-b2-backup.tftpl
+++ b/task-definition-b2-backup.tftpl
@@ -14,7 +14,7 @@
     "command": [],
     "linuxParameters": null,
     "cpu": ${cpu},
-    "environment":
+    "environment": [
       {
         "name": "ATLAS_TOKEN",
         "value": "${atlas_token}"


### PR DESCRIPTION
## Changed

* Add missing `[` in the task definition template.