### PR TITLE
Release 0.2.1 - Remove unused variable declaration

### DIFF
--- a/vars.tf
+++ b/vars.tf
@@ -11,11 +11,6 @@ variable "aws_secret_key" {
   default = null
 }
 
-variable "app_env" {
-  description = "The abbreviated app environment (e.g. prod or stg)"
-  type        = string
-}
-
 variable "app_name" {
   default = "tfcbackup"
 }


### PR DESCRIPTION
### Deleted
* `app_env` is set from the remote state so it doesn't need to be defined.